### PR TITLE
Fix mobile Messenger growth image cropping on iOS Safari

### DIFF
--- a/CSS/index.css
+++ b/CSS/index.css
@@ -438,10 +438,16 @@ body {
         background: #ccc9bf;
     }
 
+    /* Image preview: let the image's own ratio drive height so it always
+       scales to full width and is never cropped (avoids iOS Safari
+       aspect-ratio-in-table-cell bug that collapsed the box). */
+    .expand-preview--image {
+        aspect-ratio: auto;
+    }
+
     .expand-preview-img {
         width: 100%;
-        height: 100%;
-        object-fit: cover;
+        height: auto;
         display: block;
     }
 

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
                         <td colspan="3">
                             <div class="expand-inner">
                                 <p class="expand-summary">Scaled friending system and drove +2.5M friend accepts on Facebook</p>
-                                <div class="expand-preview">
+                                <div class="expand-preview expand-preview--image">
                                     <img class="expand-preview-img" src="./images/messenger-growth.png" alt="Messenger growth preview" />
                                 </div>
                             </div>


### PR DESCRIPTION
## What
Fixes the Messenger growth preview image appearing hard-cropped (zoomed into the "Barbara Johnson" card) when tapped on mobile iOS Safari. The full mockup now scales down to the column width and is always fully visible.

## Why
The mobile expand preview lives inside a `<td>`. iOS Safari mis-resolves `aspect-ratio` on a block nested in a table cell, collapsing the box; combined with `object-fit: cover` on the image, that hard-cropped it. Desktop browsers (incl. device mode) rendered it correctly, so it only reproduced on a real iPhone.

## How
For the Messenger growth mobile preview, stop forcing the container shape and let the image's own dimensions drive height:
- Added `expand-preview--image` modifier with `aspect-ratio: auto`
- Changed `.expand-preview-img` to `width: 100%; height: auto` (dropped `object-fit: cover`)

The image can no longer be cropped because layout height follows its intrinsic ratio.

## Reviewer notes
- Branched off `master`; does NOT include the 900px breakpoint change or the TV channel-flip animation (those live on `animation-for-tv-glitches`).
- Best verified on a real iOS device, since the bug did not reproduce in desktop device mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)